### PR TITLE
Omg perf!

### DIFF
--- a/apps/lonely-siblings/src/Counter.fs
+++ b/apps/lonely-siblings/src/Counter.fs
@@ -31,5 +31,5 @@ let view state dispatch =
         makeButton (fun _ -> dispatch IncrementDelayed) "Increment Delayed"
 
         br [ ] 
-        h1 [ Style [ MarginLeft 150 ] ] [ str (sprintf "%d" state.Count) ]
+        h1 [ Style [ MarginLeft 150 ] ] [ ofInt state.Count ]
     ]      

--- a/apps/lonely-siblings/src/Loader.fs
+++ b/apps/lonely-siblings/src/Loader.fs
@@ -28,8 +28,8 @@ let update msg state =
         let nextState = State.Loaded data 
         nextState, Cmd.none 
          
-    | _ ->
-        state, Cmd.none 
+    | Reset ->
+        State.Initial, Cmd.none 
 
 let spinner = 
     div [  ] [

--- a/apps/lonely-siblings/src/Settings.fs
+++ b/apps/lonely-siblings/src/Settings.fs
@@ -29,7 +29,7 @@ let view state dispatch =
       button [ OnClick (fun _ -> dispatch (ChangeFactor n))
                Style [ Margin 10 ]
                ClassName buttonClass ] 
-             [ str (sprintf "%d" n) ] 
+             [ ofInt n ] 
     
     div [ ] [ 
         factorBtn 1

--- a/apps/refactored-spaghetti-1/src/Counter.fs
+++ b/apps/refactored-spaghetti-1/src/Counter.fs
@@ -28,5 +28,5 @@ let view state dispatch =
         makeButton (fun _ -> dispatch IncrementDelayed) "Increment Delayed"
 
         br [ ] 
-        h1 [ Style [ MarginLeft 150 ] ] [ str (sprintf "%d" state.Count) ]
+        h1 [ Style [ MarginLeft 150 ] ] [ ofInt state.Count ]
     ]      

--- a/apps/refactored-spaghetti-1/src/Loader.fs
+++ b/apps/refactored-spaghetti-1/src/Loader.fs
@@ -28,8 +28,8 @@ let update msg state =
         let nextState = State.Loaded data 
         nextState, Cmd.none 
          
-    | _ ->
-        state, Cmd.none 
+    | Reset ->
+        State.Initial, Cmd.none 
 
 let spinner = 
     div [  ] [

--- a/apps/refactored-spaghetti-2/src/Counter.fs
+++ b/apps/refactored-spaghetti-2/src/Counter.fs
@@ -28,5 +28,5 @@ let view state dispatch =
         makeButton (fun _ -> dispatch IncrementDelayed) "Increment Delayed"
 
         br [ ] 
-        h1 [ Style [ MarginLeft 150 ] ] [ str (sprintf "%d" state.Count) ]
+        h1 [ Style [ MarginLeft 150 ] ] [ ofInt state.Count ]        
     ]      

--- a/apps/refactored-spaghetti-2/src/Loader.fs
+++ b/apps/refactored-spaghetti-2/src/Loader.fs
@@ -28,8 +28,8 @@ let update msg state =
         let nextState = State.Loaded data 
         nextState, Cmd.none 
          
-    | _ ->
-        state, Cmd.none 
+    | Reset ->
+        State.Initial, Cmd.none 
 
 let spinner = 
     div [  ] [

--- a/slides/index.md
+++ b/slides/index.md
@@ -64,7 +64,7 @@ Zaid Ajaj - [@zaid-ajaj](http://www.twitter.com/zaid-ajaj)
             button [ OnClick (fun _ -> dispatch Decrement) ]
                    [ str "Decrement" ]
             h1 [ ] 
-               [ str (sprintf "%d" state.Count) ] 
+               [ ofInt state.Count ] 
         ]
 
 


### PR DESCRIPTION
There is an `ofInt` helper in `Fable.Helpers.React` that turn an int into a react element without `sprintf`. 
Obviously, performance is not a goal here, but also few characters less for newcomers. Seeing `str (sprintf "%d" state.Count)` could be 😨 for anyone just to output a single number...

And fixed Reset while watching the talk :)